### PR TITLE
Fix vet error: method declared but not used

### DIFF
--- a/requester/requester_test.go
+++ b/requester/requester_test.go
@@ -99,6 +99,9 @@ func TestRequest(t *testing.T) {
 	if uri != "/" {
 		t.Errorf("Uri is expected to be /, %v is found", uri)
 	}
+	if method != "GET" {
+		t.Errorf("Method is expected to be GET, %v is found", uri)
+	}
 	if contentType != "text/html" {
 		t.Errorf("Content type is expected to be text/html, %v is found", contentType)
 	}


### PR DESCRIPTION
This PR fixes an error reported by `go vet` running `go test` complaining about the following:

```
go test ./...            
# github.com/rakyll/hey/requester
vet: requester/requester_test.go:77:30: method declared but not used
ok  	github.com/rakyll/hey	0.003s
FAIL	github.com/rakyll/hey/requester [build failed]
```

```
go version
go version go1.12.4 linux/amd64
```