### PR TITLE
Add possibility to set an User Agent per request from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Options:
   -disable-redirects    Disable following of HTTP redirects
   -cpus                 Number of used cpu cores.
                         (default for current machine is 8 cores)
+
+  -user-agent-feed      Set a User Agent for each request from file.
+						Expected on User Agent per line.
+						For example, /home/user/ua.txt or ./ua.txt.
 ```
 
 Previously known as [github.com/rakyll/boom](https://github.com/rakyll/boom).

--- a/requester/ua_feeder.go
+++ b/requester/ua_feeder.go
@@ -1,0 +1,62 @@
+// Copyright 2019 ScientiaMobile Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// userAgentFeeder allow to set a User Agent per request reading from a io.ReadSeeker feed.
+
+package requester
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"sync"
+)
+
+func newUserAgentFeeder(reader io.ReadSeeker) *userAgentFeeder {
+	return &userAgentFeeder{
+		reader:  reader,
+		scanner: bufio.NewScanner(reader),
+	}
+}
+
+type userAgentFeeder struct {
+	reader  io.ReadSeeker
+	scanner *bufio.Scanner
+	mutex   sync.Mutex
+}
+
+// userAgent returns a User Agent from the feed. When all the feed is read
+// it will restart to read from the beginning
+func (uaf *userAgentFeeder) userAgent() (string, error) {
+	uaf.mutex.Lock()
+	defer uaf.mutex.Unlock()
+	if uaf.scanner.Scan() == true {
+		return uaf.scanner.Text(), nil
+	}
+	if err := uaf.scanner.Err(); err != nil {
+		return "", err
+	}
+	uaf.reader.Seek(0, io.SeekStart)
+	uaf.scanner = bufio.NewScanner(uaf.reader)
+	return uaf.userAgent()
+}
+
+// Feed sets the request User Agent header with the feed entry. If feed entry is
+// an empty string the UserAgent won't be updated.
+func (uaf *userAgentFeeder) Feed(req *http.Request) {
+	userAgent, _ := uaf.userAgent()
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+}

--- a/requester/ua_feeder.go
+++ b/requester/ua_feeder.go
@@ -40,13 +40,16 @@ type userAgentFeeder struct {
 // it will restart to read from the beginning
 func (uaf *userAgentFeeder) userAgent() (string, error) {
 	uaf.mutex.Lock()
-	defer uaf.mutex.Unlock()
 	if uaf.scanner.Scan() == true {
-		return uaf.scanner.Text(), nil
+		ua := uaf.scanner.Text()
+		uaf.mutex.Unlock()
+		return ua, nil
 	}
 	if err := uaf.scanner.Err(); err != nil {
+		uaf.mutex.Unlock()
 		return "", err
 	}
+	uaf.mutex.Unlock()
 	uaf.reader.Seek(0, io.SeekStart)
 	uaf.scanner = bufio.NewScanner(uaf.reader)
 	return uaf.userAgent()

--- a/requester/ua_feeder_test.go
+++ b/requester/ua_feeder_test.go
@@ -1,0 +1,82 @@
+// Copyright 2019 ScientiaMobile Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package requester
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func Test_userAgentFeeder_userAgent(t *testing.T) {
+	userAgent1 := "hey/1.0"
+	userAgent2 := "hey/1.1"
+
+	reader := strings.NewReader(fmt.Sprintf("%s\n%s\n", userAgent1, userAgent2))
+	uaf := newUserAgentFeeder(reader)
+
+	got, err := uaf.userAgent()
+	if err != nil {
+		t.Errorf("userAgentFeeder.userAgent() error = %v, want nil", err)
+	}
+	expected := userAgent1
+	if got != expected {
+		t.Errorf("userAgentFeeder.userAgent() = %v, want %v", got, expected)
+	}
+
+	got, err = uaf.userAgent()
+	if err != nil {
+		t.Errorf("userAgentFeeder.userAgent() error = %v, want nil", err)
+	}
+	expected = userAgent2
+	if got != expected {
+		t.Errorf("userAgentFeeder.userAgent() = %v, want %v", got, expected)
+	}
+
+	// Lines ended should start from beginning
+	got, err = uaf.userAgent()
+	if err != nil {
+		t.Errorf("userAgentFeeder.userAgent() error = %v, want nil", err)
+	}
+	expected = userAgent1
+	if got != expected {
+		t.Errorf("userAgentFeeder.userAgent() = %v, want %v", got, expected)
+	}
+}
+
+func Test_userAgentFeeder_Feed(t *testing.T) {
+	// userAgentFeed contains also an empty feed that should fallback to
+	// userAgentDefault
+	userAgentFeed := []string{"hey/1.0.0", "", "hey/1.1.0"}
+	userAgentDefault := "hey/0.0.1"
+
+	reader := strings.NewReader(strings.Join(userAgentFeed, "\n"))
+	uaf := newUserAgentFeeder(reader)
+
+	req, _ := http.NewRequest("GET", "", nil)
+	req.Header.Set("User-Agent", userAgentDefault)
+
+	for _, ua := range userAgentFeed {
+		r := cloneRequest(req, nil)
+		uaf.Feed(r)
+		if ua == "" {
+			ua = userAgentDefault
+		}
+		if ua != r.UserAgent() {
+			t.Errorf("userAgentFeeder.Feed(req) = %v, want %v", r.UserAgent(), ua)
+		}
+	}
+}


### PR DESCRIPTION
This commit adds the `-user-agent-feed` flag that allow to set an User Agent per request from file. The file is expected to contain an User Agent per line.